### PR TITLE
Standardize from example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,7 @@ dependencies = [
  "quinn",
  "rcgen",
  "rustls",
+ "rustls-webpki",
  "sha2",
  "tokio",
 ]
@@ -747,9 +748,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ rustls  = { version = "0.23.8", default-features = false, features = ["ring", "s
 # only to generate an Ed25519 key quickly
 rcgen   = { version = "0.13", default-features = false, features = ["ring"] }
 clap = { version = "4.5.40", features = ["derive"] }
+rustls-webpki = "0.103.4"

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,13 +4,14 @@ use quinn::{Endpoint, ClientConfig as QuinnClientConfig};
 use quinn::crypto::rustls::QuicClientConfig;
 
 use rustls::{
+    Error::PeerIncompatible as PeerIncompatibleError,
     client::{
         ResolvesClientCert, AlwaysResolvesClientRawPublicKeys,
         ResolvesClientCert,
     },
     pki_types::{CertificateDer, ServerName, UnixTime},
     sign::{CertifiedKey},
-    ClientConfig, Error as RustlsError, DigitallySignedStruct,
+    ClientConfig, Error as RustlsError, DigitallySignedStruct, PeerIncompatible,
 };
 use rustls::SignatureScheme;
 use sha2::{Digest, Sha256};
@@ -50,7 +51,9 @@ impl ServerCertVerifier for AcceptAny {
     fn verify_tls12_signature(
         &self, _m: &[u8], _c: &CertificateDer, _d: &DigitallySignedStruct
     ) -> Result<HandshakeSignatureValid, RustlsError> {
-        Ok(HandshakeSignatureValid::assertion())
+        Err(PeerIncompatibleError(
+            PeerIncompatible::Tls13RequiredForQuic
+        ))
     }
     fn verify_tls13_signature(
         &self, _m: &[u8], _c: &CertificateDer, _d: &DigitallySignedStruct

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,23 +1,24 @@
 use anyhow::Result;
 use hex::encode as hex_encode;
-use quinn::{Endpoint, ClientConfig as QuinnClientConfig};
 use quinn::crypto::rustls::QuicClientConfig;
+use quinn::{ClientConfig as QuinnClientConfig, Endpoint};
 
 use rustls::pki_types::SubjectPublicKeyInfoDer;
-use rustls::{
-    Error::PeerIncompatible as PeerIncompatibleError,
-    client::{
-        AlwaysResolvesClientRawPublicKeys,
-        danger::{ServerCertVerified, ServerCertVerifier, HandshakeSignatureValid},        
-    },
-    pki_types::{CertificateDer, ServerName, UnixTime},
-    crypto::verify_tls13_signature_with_raw_key,    
-    ClientConfig, Error as RustlsError, DigitallySignedStruct, PeerIncompatible,
-};
 use rustls::SignatureScheme;
+use rustls::{
+    client::{
+        danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+        AlwaysResolvesClientRawPublicKeys,
+    },
+    crypto::verify_tls13_signature_with_raw_key,
+    pki_types::{CertificateDer, ServerName, UnixTime},
+    ClientConfig, DigitallySignedStruct, Error as RustlsError,
+    Error::PeerIncompatible as PeerIncompatibleError,
+    PeerIncompatible,
+};
 use sha2::{Digest, Sha256};
-use std::{net::SocketAddr, sync::Arc};
 use std::path::Path;
+use std::{net::SocketAddr, sync::Arc};
 
 use crate::common::{make_rpk, ED25519_ONLY};
 
@@ -35,30 +36,46 @@ impl ServerCertVerifier for AcceptAny {
         Ok(ServerCertVerified::assertion())
     }
     fn verify_tls12_signature(
-        &self, _m: &[u8], _c: &CertificateDer, _d: &DigitallySignedStruct
+        &self,
+        _m: &[u8],
+        _c: &CertificateDer,
+        _d: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, RustlsError> {
         Err(PeerIncompatibleError(
-            PeerIncompatible::Tls13RequiredForQuic
+            PeerIncompatible::Tls13RequiredForQuic,
         ))
     }
     fn verify_tls13_signature(
-        &self, _m: &[u8], _c: &CertificateDer, _d: &DigitallySignedStruct
+        &self,
+        _m: &[u8],
+        _c: &CertificateDer,
+        _d: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, RustlsError> {
-        verify_tls13_signature_with_raw_key(_m, &SubjectPublicKeyInfoDer::from(_c.as_ref()), _d, &ED25519_ONLY)
+        verify_tls13_signature_with_raw_key(
+            _m,
+            &SubjectPublicKeyInfoDer::from(_c.as_ref()),
+            _d,
+            &ED25519_ONLY,
+        )
     }
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        vec![
-            SignatureScheme::ED25519
-        ]
+        vec![SignatureScheme::ED25519]
     }
     fn requires_raw_public_keys(&self) -> bool {
         true
     }
 }
 
-pub async fn run_client(server_addr: SocketAddr, key_path: Option<&Path>, cert_path: Option<&Path>) -> Result<()> {
+pub async fn run_client(
+    server_addr: SocketAddr,
+    key_path: Option<&Path>,
+    cert_path: Option<&Path>,
+) -> Result<()> {
     let client_rpk = make_rpk(key_path, cert_path, "client.key", "client.crt")?;
-    println!("client ‣ my id {}", hex_encode(Sha256::digest(&client_rpk.cert[0])));
+    println!(
+        "client ‣ my id {}",
+        hex_encode(Sha256::digest(&client_rpk.cert[0]))
+    );
 
     let tls = ClientConfig::builder()
         .dangerous()

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,12 +7,11 @@ use rustls::pki_types::SubjectPublicKeyInfoDer;
 use rustls::{
     Error::PeerIncompatible as PeerIncompatibleError,
     client::{
-        ResolvesClientCert, AlwaysResolvesClientRawPublicKeys,
+        AlwaysResolvesClientRawPublicKeys,
         danger::{ServerCertVerified, ServerCertVerifier, HandshakeSignatureValid},        
     },
     pki_types::{CertificateDer, ServerName, UnixTime},
-    crypto::verify_tls13_signature_with_raw_key,
-    sign::{CertifiedKey},
+    crypto::verify_tls13_signature_with_raw_key,    
     ClientConfig, Error as RustlsError, DigitallySignedStruct, PeerIncompatible,
 };
 use rustls::SignatureScheme;

--- a/src/client.rs
+++ b/src/client.rs
@@ -65,6 +65,9 @@ impl ServerCertVerifier for AcceptAny {
             SignatureScheme::ED25519
         ]
     }
+    fn requires_raw_public_keys(&self) -> bool {
+        true
+    }
 }
 
 pub async fn run_client(server_addr: SocketAddr, key_path: Option<&Path>, cert_path: Option<&Path>) -> Result<()> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,7 @@ use quinn::crypto::rustls::QuicClientConfig;
 
 use rustls::{
     client::{
-        danger::{ServerCertVerified, ServerCertVerifier, HandshakeSignatureValid},
+        ResolvesClientCert, AlwaysResolvesClientRawPublicKeys,
         ResolvesClientCert,
     },
     pki_types::{CertificateDer, ServerName, UnixTime},
@@ -71,7 +71,7 @@ pub async fn run_client(server_addr: SocketAddr, key_path: Option<&Path>, cert_p
     let tls = ClientConfig::builder()
         .dangerous()
         .with_custom_certificate_verifier(Arc::new(AcceptAny))
-        .with_client_cert_resolver(Arc::new(OneRpk(client_rpk)));
+        .with_client_cert_resolver(Arc::new(AlwaysResolvesClientRawPublicKeys::new(client_rpk)));
 
     let crypto = QuicClientConfig::try_from(Arc::new(tls))?;
     let cfg = QuinnClientConfig::new(Arc::new(crypto));

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,14 +1,22 @@
 use rcgen::KeyPair;
 use rcgen::PKCS_ED25519;
+// use rustls::pki_types::alg_id::ED25519;
 use rustls::{
     pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
     sign::{CertifiedKey, SigningKey},
-    crypto::ring::sign::any_eddsa_type,
+    crypto::{ring::sign::any_eddsa_type, WebPkiSupportedAlgorithms},
+    SignatureScheme,
 };
+use webpki::ring::ED25519;
 use std::sync::Arc;
 use std::fs;
 use std::path::Path;
 use anyhow::{anyhow, Result, Context};
+
+pub static ED25519_ONLY: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
+    all: &[ED25519],
+    mapping: &[(SignatureScheme::ED25519, &[ED25519])]
+};
 
 pub fn make_rpk(
     key_path: Option<&Path>, 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,49 +1,57 @@
 use rcgen::KeyPair;
 use rcgen::PKCS_ED25519;
 
+use anyhow::{anyhow, Context, Result};
 use rustls::{
+    crypto::{ring::sign::any_eddsa_type, WebPkiSupportedAlgorithms},
     pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
     sign::{CertifiedKey, SigningKey},
-    crypto::{ring::sign::any_eddsa_type, WebPkiSupportedAlgorithms},
     SignatureScheme,
 };
-use webpki::ring::ED25519;
-use std::sync::Arc;
 use std::fs;
 use std::path::Path;
-use anyhow::{anyhow, Result, Context};
+use std::sync::Arc;
+use webpki::ring::ED25519;
 
 pub static ED25519_ONLY: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
     all: &[ED25519],
-    mapping: &[(SignatureScheme::ED25519, &[ED25519])]
+    mapping: &[(SignatureScheme::ED25519, &[ED25519])],
 };
 
 pub fn make_rpk(
-    key_path: Option<&Path>, 
+    key_path: Option<&Path>,
     cert_path: Option<&Path>,
     default_key_path: &str,
-    default_cert_path: &str
+    default_cert_path: &str,
 ) -> Result<Arc<CertifiedKey>> {
     let key_file = key_path.unwrap_or(Path::new(default_key_path));
     let cert_file = cert_path.unwrap_or(Path::new(default_cert_path));
-    
+
     if key_file.exists() && cert_file.exists() && key_path.is_none() && cert_path.is_none() {
         match load_rpk_from_files(key_file, cert_file) {
             Ok(rpk) => {
-                println!("Loaded existing RPK from {} and {}", key_file.display(), cert_file.display());
+                println!(
+                    "Loaded existing RPK from {} and {}",
+                    key_file.display(),
+                    cert_file.display()
+                );
                 return Ok(rpk);
             }
             Err(e) => {
-                println!("Failed to load existing RPK files: {}, generating new ones", e);
+                println!("Failed to load existing RPK files: {e}, generating new ones");
             }
         }
     }
-    
+
     if key_path.is_some() || cert_path.is_some() {
         if key_file.exists() && cert_file.exists() {
             match load_rpk_from_files(key_file, cert_file) {
                 Ok(rpk) => {
-                    println!("Loaded RPK from {} and {}", key_file.display(), cert_file.display());
+                    println!(
+                        "Loaded RPK from {} and {}",
+                        key_file.display(),
+                        cert_file.display()
+                    );
                     return Ok(rpk);
                 }
                 Err(e) => {
@@ -52,54 +60,63 @@ pub fn make_rpk(
             }
         } else {
             return Err(anyhow!(
-                "Specified key or cert file does not exist: {} or {}", 
-                key_file.display(), 
+                "Specified key or cert file does not exist: {} or {}",
+                key_file.display(),
                 cert_file.display()
             ));
         }
     }
-    
+
     let kp = KeyPair::generate_for(&PKCS_ED25519).context("Failed to generate ED25519 keypair")?;
     let spki = CertificateDer::from(kp.public_key_der());
     let pkcs8_key = PrivatePkcs8KeyDer::from(kp.serialize_der());
-    let sk: Arc<dyn SigningKey> = any_eddsa_type(&pkcs8_key)
-        .context("Failed to create signing key")?;
+    let sk: Arc<dyn SigningKey> =
+        any_eddsa_type(&pkcs8_key).context("Failed to create signing key")?;
     let rpk = Arc::new(CertifiedKey::new(vec![spki.clone()], sk));
-    
+
     save_rpk_to_files(&kp, &spki, key_file, cert_file)?;
-    println!("Generated and saved new ED25519 RPK to {} and {}", key_file.display(), cert_file.display());
-    
+    println!(
+        "Generated and saved new ED25519 RPK to {} and {}",
+        key_file.display(),
+        cert_file.display()
+    );
+
     Ok(rpk)
 }
 
 fn load_rpk_from_files(key_file: &Path, cert_file: &Path) -> Result<Arc<CertifiedKey>> {
     let key_der = fs::read(key_file)
         .with_context(|| format!("Failed to read key file: {}", key_file.display()))?;
-    
+
     let cert_der = fs::read(cert_file)
         .with_context(|| format!("Failed to read cert file: {}", cert_file.display()))?;
-        
+
     let private_key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_der));
     let pkcs8_key = match private_key {
         PrivateKeyDer::Pkcs8(pkcs8) => pkcs8,
         _ => return Err(anyhow!("Ed25519 keys must be in PKCS8 format")),
     };
-    
-    let sk: Arc<dyn SigningKey> = any_eddsa_type(&pkcs8_key)
-        .context("Failed to create signing key from loaded key")?;
-    
+
+    let sk: Arc<dyn SigningKey> =
+        any_eddsa_type(&pkcs8_key).context("Failed to create signing key from loaded key")?;
+
     let cert = CertificateDer::from(cert_der);
-    
+
     Ok(Arc::new(CertifiedKey::new(vec![cert], sk)))
 }
 
-fn save_rpk_to_files(kp: &KeyPair, cert: &CertificateDer, key_file: &Path, cert_file: &Path) -> Result<()> {
+fn save_rpk_to_files(
+    kp: &KeyPair,
+    cert: &CertificateDer,
+    key_file: &Path,
+    cert_file: &Path,
+) -> Result<()> {
     let key_der = kp.serialize_der();
     fs::write(key_file, key_der)
         .with_context(|| format!("Failed to write key file: {}", key_file.display()))?;
-        
+
     fs::write(cert_file, cert.as_ref())
         .with_context(|| format!("Failed to write cert file: {}", cert_file.display()))?;
-    
+
     Ok(())
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,6 @@
 use rcgen::KeyPair;
 use rcgen::PKCS_ED25519;
-// use rustls::pki_types::alg_id::ED25519;
+
 use rustls::{
     pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
     sign::{CertifiedKey, SigningKey},

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,31 +2,29 @@ mod client;
 mod common;
 mod server;
 
-use clap::{Args, Parser, Subcommand};
-use std::{
-    net::SocketAddr, path::PathBuf
-};
 use anyhow::Result;
+use clap::{Args, Parser, Subcommand};
+use std::{net::SocketAddr, path::PathBuf};
 
 use client::run_client;
 use server::run_server;
 
 #[derive(Debug, Args)]
 struct ClientArgs {
-    #[clap(long, default_value="127.0.0.1:4433")]
-    server: SocketAddr
+    #[clap(long, default_value = "127.0.0.1:4433")]
+    server: SocketAddr,
 }
 
 #[derive(Debug, Args)]
 struct ServerArgs {
     #[clap(long, default_value = "127.0.0.1:4433")]
-    listen: SocketAddr
+    listen: SocketAddr,
 }
 
 #[derive(Debug, Subcommand)]
 enum RunMode {
     Client(ClientArgs),
-    Server(ServerArgs)
+    Server(ServerArgs),
 }
 
 #[derive(Debug, clap::Args)]
@@ -34,7 +32,7 @@ struct GlobalArgs {
     #[clap(long)]
     key: Option<PathBuf>,
     #[clap(long)]
-    cert: Option<PathBuf>
+    cert: Option<PathBuf>,
 }
 
 #[derive(Debug, Parser)]
@@ -43,29 +41,31 @@ struct Cli {
     global: GlobalArgs,
 
     #[clap(subcommand)]
-    mode: RunMode
+    mode: RunMode,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Cli::parse();
-    
+
     match args.mode {
         RunMode::Client(client_args) => {
             println!("Client mode");
             run_client(
                 client_args.server,
                 args.global.key.as_deref(),
-                args.global.cert.as_deref()
-            ).await?;
+                args.global.cert.as_deref(),
+            )
+            .await?;
         }
         RunMode::Server(server_args) => {
             println!("Server mode");
             run_server(
                 server_args.listen,
                 args.global.key.as_deref(),
-                args.global.cert.as_deref()
-            ).await?;
+                args.global.cert.as_deref(),
+            )
+            .await?;
         }
     }
     Ok(())

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,11 +4,12 @@ use quinn::{Endpoint, ServerConfig as QuinnServerConfig};
 use quinn::crypto::rustls::QuicServerConfig;
 
 use rustls::{
+    Error::PeerIncompatible as PeerIncompatibleError,
     pki_types::{CertificateDer, UnixTime},
     sign::{CertifiedKey},
     server::{ResolvesServerCert, ServerConfig, ClientHello, AlwaysResolvesServerRawPublicKeys, danger::{ClientCertVerified, ClientCertVerifier}},
     client::danger::HandshakeSignatureValid,
-    SignatureScheme, Error, DistinguishedName, DigitallySignedStruct,
+    SignatureScheme, Error, DistinguishedName, DigitallySignedStruct, PeerIncompatible,
 };
 use sha2::{Digest, Sha256};
 use std::{net::SocketAddr, sync::Arc, path::Path};
@@ -29,7 +30,9 @@ impl ClientCertVerifier for AcceptAnyClient {
     fn verify_tls12_signature(
         &self, _message: &[u8], _cert: &CertificateDer, _dss: &DigitallySignedStruct
     ) -> Result<HandshakeSignatureValid, Error> {
-        Ok(HandshakeSignatureValid::assertion())
+        Err(PeerIncompatibleError(
+            PeerIncompatible::Tls13RequiredForQuic
+        ))
     }
     fn verify_tls13_signature(
         &self, _message: &[u8], _cert: &CertificateDer, _dss: &DigitallySignedStruct

--- a/src/server.rs
+++ b/src/server.rs
@@ -50,6 +50,9 @@ impl ClientCertVerifier for AcceptAnyClient {
     fn client_auth_mandatory(&self) -> bool {
         true
     }
+    fn requires_raw_public_keys(&self) -> bool {
+        true
+    }
 }
 
 pub async fn run_server(listen_addr: SocketAddr, key_path: Option<&Path>, cert_path: Option<&Path>) -> Result<()> {    

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,8 +8,7 @@ use rustls::pki_types::SubjectPublicKeyInfoDer;
 use rustls::{
     Error::PeerIncompatible as PeerIncompatibleError,
     pki_types::{CertificateDer, UnixTime},
-    sign::{CertifiedKey},
-    server::{ResolvesServerCert, ServerConfig, ClientHello, AlwaysResolvesServerRawPublicKeys, danger::{ClientCertVerified, ClientCertVerifier}},
+    server::{ServerConfig, AlwaysResolvesServerRawPublicKeys, danger::{ClientCertVerified, ClientCertVerifier}},
     client::danger::HandshakeSignatureValid,
     SignatureScheme, Error, DistinguishedName, DigitallySignedStruct, PeerIncompatible,
 };


### PR DESCRIPTION
This uses the example at [](https://github.com/rustls/rustls/blob/7b0a8ee6493bad2fde3fbf082df4e58cf8e3745e/openssl-tests/src/raw_key_openssl_interop.rs) to work out some kinks in the implementation.

- uses standard cert resolvers 
- implements requires_raw_public_keys on the verifier traits
- removes tls 1.2 support with PeerIncompatible::Tls13RequiredForQuic
- fixes verification logic and ensures only ed25519 is available
- fmt and clippy changes